### PR TITLE
Feat: Add drag-and-drop functionality for moving events in the calendar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,9 @@
 <h1 align="center">
+NOTE : THIS MODULE IS IN ALPHA STAGE AND IS NOT READY FOR PRODUCTION USE.
+THERE MAY BE BREAKING CHANGES IN FUTURE RELEASES AND THE API IS NOT FINALIZED.
+ANY FEEDBACK IS WELCOME, BUT PLEASE DO NOT USE THIS MODULE IN PRODUCTION UNTIL IT IS STABLE.
+</h1>
+<h1 align="center">
   <img src="./assets/FastCalendarIcon.png" alt="Fast Calendar" width="300" height="300" />
   <br/>
   Fast React Calendar

--- a/src/components/Calendar/CellEvent.tsx
+++ b/src/components/Calendar/CellEvent.tsx
@@ -15,8 +15,6 @@ export const CellEvent = ({
             draggable
             onDragStart={(e) => {
                 e.stopPropagation();
-                console.log("Dragging event:", event);
-                
                 e.dataTransfer.setData(
                     "application/json",
                     JSON.stringify(event)

--- a/src/components/Calendar/CellEvent.tsx
+++ b/src/components/Calendar/CellEvent.tsx
@@ -4,11 +4,32 @@ import { CalendarEvent } from "../../types/date";
 interface CellEventProps {
     event: CalendarEvent;
     showTitle?: boolean;
+    onDragStart?: (event: CalendarEvent, e: React.DragEvent) => void;
+    onDragEnd?: (event: CalendarEvent, e: React.DragEvent) => void;
 }
 
-export const CellEvent = ({ event, showTitle = true }: CellEventProps) => {
+export const CellEvent = ({
+    event,
+    showTitle = true,
+    onDragStart,
+    onDragEnd,
+}: CellEventProps) => {
     return (
         <Box
+            draggable
+            onDragStart={(e) => {
+                e.stopPropagation();
+                console.log("Dragging event:", event);
+                
+                e.dataTransfer.setData(
+                    "application/json",
+                    JSON.stringify(event)
+                );
+                onDragStart?.(event, e);
+            }}
+            onDragEnd={(e) => {
+                onDragEnd?.(event, e);
+            }}
             sx={{
                 display: "flex",
                 gap: "4px",
@@ -17,11 +38,12 @@ export const CellEvent = ({ event, showTitle = true }: CellEventProps) => {
                 border: `1px solid ${event.color}`,
                 borderRadius: "10px",
                 cursor: "pointer",
-                transition: "background-color 0.2s, box-shadow 0.2s ease-in-out",
+                transition:
+                    "background-color 0.2s, box-shadow 0.2s ease-in-out",
                 "&:hover": {
                     backgroundColor: alpha(event.color, 0.3),
                     boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                }
+                },
             }}
         >
             <Typography
@@ -40,7 +62,7 @@ export const CellEvent = ({ event, showTitle = true }: CellEventProps) => {
                             whiteSpace: "nowrap",
                             color: event.color,
                             fontWeight: 500,
-                            cursor: "pointer"
+                            cursor: "pointer",
                         }}
                     >
                         {event.title}

--- a/src/components/Calendar/CellEvent.tsx
+++ b/src/components/Calendar/CellEvent.tsx
@@ -4,15 +4,11 @@ import { CalendarEvent } from "../../types/date";
 interface CellEventProps {
     event: CalendarEvent;
     showTitle?: boolean;
-    onDragStart?: (event: CalendarEvent, e: React.DragEvent) => void;
-    onDragEnd?: (event: CalendarEvent, e: React.DragEvent) => void;
 }
 
 export const CellEvent = ({
     event,
     showTitle = true,
-    onDragStart,
-    onDragEnd,
 }: CellEventProps) => {
     return (
         <Box
@@ -25,7 +21,6 @@ export const CellEvent = ({
                     "application/json",
                     JSON.stringify(event)
                 );
-                onDragStart?.(event, e);
             }}
             sx={{
                 display: "flex",

--- a/src/components/Calendar/CellEvent.tsx
+++ b/src/components/Calendar/CellEvent.tsx
@@ -27,9 +27,6 @@ export const CellEvent = ({
                 );
                 onDragStart?.(event, e);
             }}
-            onDragEnd={(e) => {
-                onDragEnd?.(event, e);
-            }}
             sx={{
                 display: "flex",
                 gap: "4px",

--- a/src/components/Calendar/FastCell.tsx
+++ b/src/components/Calendar/FastCell.tsx
@@ -9,16 +9,12 @@ import { useState } from "react";
 interface FastCellProps {
     cell: CalendarCell;
     index: number;
-    onEventDragStart: (event: CalendarEvent, e: React.DragEvent) => void;
-    onEventDragEnd: (event: CalendarEvent, e: React.DragEvent) => void;
     onEventDrop: (event: CalendarEvent, e: React.DragEvent) => void;
 }
 
 export const FastCell = ({
     cell,
     index,
-    onEventDragStart,
-    onEventDragEnd,
     onEventDrop,
 }: FastCellProps) => {
     const [dragCounter, setDragCounter] = useState(0);
@@ -117,11 +113,9 @@ export const FastCell = ({
                 >
                     {cell.events.map((event, eventIndex) => (
                         <CellEvent
-                            key={eventIndex}
+                            key={`${event.id}-${eventIndex}`}
                             event={event}
                             showTitle={true}
-                            onDragStart={onEventDragStart}
-                            onDragEnd={onEventDragEnd}
                         />
                     ))}
                 </Box>

--- a/src/components/Calendar/FastCell.tsx
+++ b/src/components/Calendar/FastCell.tsx
@@ -1,35 +1,81 @@
 import { Box, Typography } from "@mui/material";
-import { CalendarCell } from "../../types/date";
+import { CalendarCell, CalendarEvent } from "../../types/date";
 import { CellEvent } from "./CellEvent";
 import { format } from "date-fns";
 import { capitalize, getDateFnsLocale } from "../../utils/date";
 import { useLocale } from "../../context/LocalContext";
+import { useState } from "react";
 
 interface FastCellProps {
     cell: CalendarCell;
     index: number;
+    onEventDragStart: (event: CalendarEvent, e: React.DragEvent) => void;
+    onEventDragEnd: (event: CalendarEvent, e: React.DragEvent) => void;
+    onEventDrop: (event: CalendarEvent, e: React.DragEvent) => void;
 }
 
-export const FastCell = ({ cell, index }: FastCellProps) => {
+export const FastCell = ({
+    cell,
+    index,
+    onEventDragStart,
+    onEventDragEnd,
+    onEventDrop,
+}: FastCellProps) => {
+    const [dragCounter, setDragCounter] = useState(0);
+    const isDragOver = dragCounter > 0;
+
     const locale = useLocale();
     const isCurrentDay = cell.date
         ? cell.date.toDateString() === new Date().toDateString()
         : false;
 
+    const handleDragEnter = (e: React.DragEvent) => {
+        e.preventDefault();
+        setDragCounter((prev) => prev + 1);
+    };
+
+    const handleDragLeave = (e: React.DragEvent) => {
+        e.preventDefault();
+        setDragCounter((prev) => Math.max(prev - 1, 0));
+    };
+
+    const handleDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+    };
+
+    const handleDrop = (e: React.DragEvent) => {
+        e.preventDefault();
+        setDragCounter(0);
+        const data = e.dataTransfer.getData("application/json");
+        if (data) {
+            const event: CalendarEvent = JSON.parse(data);
+            onEventDrop(event, e);
+        }
+    };
+
     return (
         <Box
             key={index}
+            onDragOver={handleDragOver}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
             sx={{
                 width: "100%",
                 aspectRatio: "1",
                 position: "relative",
                 borderRadius: 2,
                 border: (theme) =>
-                    cell.isCurrentMonth
+                    isDragOver
+                        ? `2px solid ${theme.palette.primary.main}`
+                        : cell.isCurrentMonth
                         ? `1px solid ${theme.palette.text.disabled}`
                         : `1px solid ${theme.palette.divider}`,
                 fontWeight: 500,
                 overflow: "hidden",
+                transition: "border-color 0.2s ease-in-out",
+                boxSizing: "border-box",
             }}
         >
             <Typography
@@ -74,6 +120,8 @@ export const FastCell = ({ cell, index }: FastCellProps) => {
                             key={eventIndex}
                             event={event}
                             showTitle={true}
+                            onDragStart={onEventDragStart}
+                            onDragEnd={onEventDragEnd}
                         />
                     ))}
                 </Box>

--- a/src/components/Calendar/FastGrid.tsx
+++ b/src/components/Calendar/FastGrid.tsx
@@ -86,7 +86,6 @@ export const FastGrid = ({
                         cell={cell}
                         index={index}
                         onEventDrop={(event, e) => {
-                            console.log("Drop ", event, e);
                             const newDate = cell.date;
                             const eventStartDate = new Date(event.start);
                             const eventEndDate = new Date(

--- a/src/components/Calendar/FastGrid.tsx
+++ b/src/components/Calendar/FastGrid.tsx
@@ -20,6 +20,7 @@ interface FastGridProps {
     components?: {
         loading?: React.ComponentType;
     };
+    onEventChange?: (event: CalendarEvent) => void;
 }
 
 export const FastGrid = ({
@@ -28,6 +29,7 @@ export const FastGrid = ({
     events,
     loading,
     components,
+    onEventChange,
 }: FastGridProps) => {
     const locale = useLocale();
 
@@ -79,7 +81,49 @@ export const FastGrid = ({
                 }}
             >
                 {days.map((cell, index) => (
-                    <FastCell key={index} cell={cell} index={index} />
+                    <FastCell
+                        key={index}
+                        cell={cell}
+                        index={index}
+                        onEventDragEnd={(event, e) =>
+                            console.log("Drag End ", event, e)
+                        }
+                        onEventDragStart={(event, e) =>
+                            console.log("Drag Start ", event, e)
+                        }
+                        onEventDrop={(event, e) => {
+                            console.log("Drop ", event, e);
+                            const newDate = cell.date;
+                            const eventStartDate = new Date(event.start);
+                            const eventEndDate = new Date(
+                                event.end || event.start
+                            );
+
+                            if (newDate && onEventChange) {
+                                const newStart = new Date(
+                                    newDate.getFullYear(),
+                                    newDate.getMonth(),
+                                    newDate.getDate(),
+                                    eventStartDate.getHours(),
+                                    eventStartDate.getMinutes()
+                                );
+
+                                const durationMs =
+                                    eventEndDate.getTime() -
+                                    eventStartDate.getTime();
+
+                                const newEnd = event.end
+                                    ? new Date(newStart.getTime() + durationMs)
+                                    : undefined;
+
+                                onEventChange({
+                                    ...event,
+                                    start: newStart,
+                                    end: newEnd,
+                                });
+                            }
+                        }}
+                    />
                 ))}
             </Box>
             {loading && (

--- a/src/components/Calendar/FastGrid.tsx
+++ b/src/components/Calendar/FastGrid.tsx
@@ -85,12 +85,6 @@ export const FastGrid = ({
                         key={index}
                         cell={cell}
                         index={index}
-                        onEventDragEnd={(event, e) =>
-                            console.log("Drag End ", event, e)
-                        }
-                        onEventDragStart={(event, e) =>
-                            console.log("Drag Start ", event, e)
-                        }
                         onEventDrop={(event, e) => {
                             console.log("Drop ", event, e);
                             const newDate = cell.date;

--- a/src/components/FastCalendar.tsx
+++ b/src/components/FastCalendar.tsx
@@ -64,7 +64,7 @@ export const FastCalendar = ({
                         };
                         try {
                             if (onAddEvent) {
-                                await Promise.resolve(onAddEvent(event));
+                                await Promise.resolve(onAddEvent(newEvent));
                             } else {
                                 setCalendarEvents((prev) => [
                                     ...prev,

--- a/src/components/FastCalendar.tsx
+++ b/src/components/FastCalendar.tsx
@@ -8,7 +8,6 @@ import { Components, DataState } from "../types/calendar";
 import { ErrorFallback } from "./Fallbacks/ErrorFallback";
 import { renderOptionalComponent } from "../utils/render";
 import { LocaleContext } from "../context/LocalContext";
-import { useEvents } from "../hooks/useEvents";
 
 interface FastCalendarProps {
     events?: CalendarEvent[];
@@ -63,11 +62,18 @@ export const FastCalendar = ({
                             icon: event.icon ?? "",
                             color: event.color ?? "",
                         };
-
-                        if (onAddEvent) {
-                            await Promise.resolve(onAddEvent(event));
+                        try {
+                            if (onAddEvent) {
+                                await Promise.resolve(onAddEvent(event));
+                            } else {
+                                setCalendarEvents((prev) => [
+                                    ...prev,
+                                    newEvent,
+                                ]);
+                            }
+                        } catch (error) {
+                            console.error("Error adding event:", error);
                         }
-                        setCalendarEvents((prev) => [...prev, newEvent]);
                     }}
                 />
                 <FastGrid
@@ -82,18 +88,23 @@ export const FastCalendar = ({
                         if (typeof changedEvent.id === "undefined") {
                             return;
                         }
-
-                        if (onEventChange) {
-                            await Promise.resolve(onEventChange(changedEvent));
+                        try {
+                            if (onEventChange) {
+                                await Promise.resolve(
+                                    onEventChange(changedEvent)
+                                );
+                            } else {
+                                setCalendarEvents((prev) =>
+                                    prev.map((ev) =>
+                                        ev.id === changedEvent.id
+                                            ? { ...ev, ...changedEvent }
+                                            : ev
+                                    )
+                                );
+                            }
+                        } catch (error) {
+                            console.error("Error updating event:", error);
                         }
-
-                        setCalendarEvents((prev) =>
-                            prev.map((ev) =>
-                                ev.id === changedEvent.id
-                                    ? { ...ev, ...changedEvent }
-                                    : ev
-                            )
-                        );
                     }}
                 />
             </FastContainer>


### PR DESCRIPTION
- User is able to drag and drop events, we automatically place end date of the event.
- Devs are able to use async `onEventChange` prop from FastCalendar, there's an example :
```ts
const onEventChange = async (updatedEvent: CalendarEvent) => {
    console.log("[onEventChange] Simulating API update...", updatedEvent);

    await new Promise((resolve) => setTimeout(resolve, 1000));

    setEvents((prevEvents) =>
      prevEvents.map((e) => (e.id === updatedEvent.id ? updatedEvent : e))
    );

    console.log("[onEventChange] Updated event applied.");
  };
<FastCalendar
     onEventChange={onEventChange}
/>
```

![dnd](https://github.com/user-attachments/assets/8602fbbf-4a29-4460-97b9-52fa8a01e96d)