### PR TITLE
Feat: Added external API reference for FastCalendar

### DIFF
--- a/src/components/FastCalendar.tsx
+++ b/src/components/FastCalendar.tsx
@@ -1,27 +1,16 @@
-import { useEffect, useState } from "react";
+import { forwardRef, RefObject, useEffect, useRef, useState } from "react";
 
 import { FastContainer } from "./FastContainer";
 import { FastHeader } from "./Header/FastHeader";
 import { FastGrid } from "./Calendar/FastGrid";
 import { CalendarEvent, MonthIndex, NewCalendarEvent } from "../types/date";
-import { Components, DataState } from "../types/calendar";
+import { CalendarApiRef, Components, DataState, FastCalendarProps } from "../types/calendar";
 import { ErrorFallback } from "./Fallbacks/ErrorFallback";
 import { renderOptionalComponent } from "../utils/render";
 import { LocaleContext } from "../context/LocalContext";
 
-interface FastCalendarProps {
-    events?: CalendarEvent[];
-    dataState?: DataState;
-    components?: Components;
-    locale?: string;
-    onAddEvent?: (event: NewCalendarEvent) => void | Promise<void>;
-    onEventChange?: (event: CalendarEvent) => void | Promise<void>;
-}
-
-/**
- * @param {CalendarEvent[]} events - Array of calendar events for the month
- */
 export const FastCalendar = ({
+    apiRef,
     events,
     dataState,
     components,
@@ -37,11 +26,75 @@ export const FastCalendar = ({
     );
     const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
 
+    const internalRef = useRef<CalendarApiRef>({
+        goToToday: () => {
+            const today = new Date();
+            setSelectedMonth(today.getMonth() as MonthIndex);
+            setSelectedYear(today.getFullYear());
+        },
+        setMonth: (month: MonthIndex) => {
+            setSelectedMonth(month);
+        },
+        setYear: (year: number) => {
+            setSelectedYear(year);
+        },
+        setDate: (date: Date) => {
+            setSelectedMonth(date.getMonth() as MonthIndex);
+            setSelectedYear(date.getFullYear());
+        },
+    });
+
     useEffect(() => {
         if (events) {
             setCalendarEvents(events);
         }
     }, [events]);
+
+    useEffect(() => {
+        if (apiRef) {
+            apiRef.current = internalRef.current;
+        }
+    }, [apiRef]);
+
+    const onAddEventHandler = async (event: NewCalendarEvent) => {
+        let newEvent: CalendarEvent = {
+            ...event,
+            id: crypto.randomUUID(),
+            icon: event.icon ?? "",
+            color: event.color ?? "",
+        };
+        try {
+            if (onAddEvent) {
+                await Promise.resolve(onAddEvent(newEvent));
+            } else {
+                setCalendarEvents((prev) => [...prev, newEvent]);
+            }
+        } catch (error) {
+            console.error("Error adding event:", error);
+        }
+    };
+
+    const onEventChangeHandler = async (changedEvent: CalendarEvent) => {
+        if (typeof changedEvent.id === "undefined") {
+            return;
+        }
+
+        try {
+            if (onEventChange) {
+                await Promise.resolve(onEventChange(changedEvent));
+            } else {
+                setCalendarEvents((prev) =>
+                    prev.map((ev) =>
+                        ev.id === changedEvent.id
+                            ? { ...ev, ...changedEvent }
+                            : ev
+                    )
+                );
+            }
+        } catch (error) {
+            console.error("Error updating event:", error);
+        }
+    };
 
     return (
         <LocaleContext.Provider value={locale}>
@@ -55,26 +108,7 @@ export const FastCalendar = ({
                     setSelectedMonth={setSelectedMonth}
                     selectedYear={selectedYear}
                     setSelectedYear={setSelectedYear}
-                    onAddEvent={async (event) => {
-                        let newEvent: CalendarEvent = {
-                            ...event,
-                            id: crypto.randomUUID(),
-                            icon: event.icon ?? "",
-                            color: event.color ?? "",
-                        };
-                        try {
-                            if (onAddEvent) {
-                                await Promise.resolve(onAddEvent(newEvent));
-                            } else {
-                                setCalendarEvents((prev) => [
-                                    ...prev,
-                                    newEvent,
-                                ]);
-                            }
-                        } catch (error) {
-                            console.error("Error adding event:", error);
-                        }
-                    }}
+                    onAddEvent={onAddEventHandler}
                 />
                 <FastGrid
                     year={selectedYear}
@@ -84,28 +118,7 @@ export const FastCalendar = ({
                     components={{
                         loading: components?.loading,
                     }}
-                    onEventChange={async (changedEvent) => {
-                        if (typeof changedEvent.id === "undefined") {
-                            return;
-                        }
-                        try {
-                            if (onEventChange) {
-                                await Promise.resolve(
-                                    onEventChange(changedEvent)
-                                );
-                            } else {
-                                setCalendarEvents((prev) =>
-                                    prev.map((ev) =>
-                                        ev.id === changedEvent.id
-                                            ? { ...ev, ...changedEvent }
-                                            : ev
-                                    )
-                                );
-                            }
-                        } catch (error) {
-                            console.error("Error updating event:", error);
-                        }
-                    }}
+                    onEventChange={onEventChangeHandler}
                 />
             </FastContainer>
         </LocaleContext.Provider>

--- a/src/components/FastCalendar.tsx
+++ b/src/components/FastCalendar.tsx
@@ -1,10 +1,10 @@
-import { forwardRef, RefObject, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { FastContainer } from "./FastContainer";
 import { FastHeader } from "./Header/FastHeader";
 import { FastGrid } from "./Calendar/FastGrid";
 import { CalendarEvent, MonthIndex, NewCalendarEvent } from "../types/date";
-import { CalendarApiRef, Components, DataState, FastCalendarProps } from "../types/calendar";
+import { CalendarApiRef, FastCalendarProps } from "../types/calendar";
 import { ErrorFallback } from "./Fallbacks/ErrorFallback";
 import { renderOptionalComponent } from "../utils/render";
 import { LocaleContext } from "../context/LocalContext";

--- a/src/hooks/useApiRef.ts
+++ b/src/hooks/useApiRef.ts
@@ -1,0 +1,6 @@
+import { useRef } from "react"
+import { CalendarApiRef } from "../types/calendar";
+
+export const useApiRef = () => {
+    return useRef<CalendarApiRef>(null);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export * from './components/FastCalendar';
 export * from './hooks/useEvents';
+export * from './hooks/useApiRef';
 export { type CalendarEvent } from './types/date'

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,3 +1,67 @@
+import { RefObject } from "react";
+import { CalendarEvent, MonthIndex, NewCalendarEvent } from "./date";
+
+export interface FastCalendarProps {
+    /**
+     * Reference to the calendar API instance
+     */
+    apiRef?: RefObject<CalendarApiRef | null>;
+
+    /**
+     * Array of calendar events for the month
+     */
+    events?: CalendarEvent[];
+
+    /**
+     * State of the calendar data (loading, error)
+     */
+    dataState?: DataState;
+
+    /**
+     * Optional components to override default rendering
+     */
+    components?: Components;
+
+    /**
+     * Locale used for calendar formatting (e.g. day names, month labels).
+     * Defaults to `"en-US"`.
+     * Should follow [IETF BCP 47 language tags](https://www.rfc-editor.org/rfc/bcp/bcp47.txt),
+     * like `"fr"`, `"en-GB"`, `"de"`, etc.
+     */
+    locale?: string;
+
+    /**
+     * Callback triggered when a new event is added
+     */
+    onAddEvent?: (event: NewCalendarEvent) => void | Promise<void>;
+
+    /**
+     * Callback triggered when an existing event is changed
+     */
+    onEventChange?: (event: CalendarEvent) => void | Promise<void>;
+}
+
+export interface CalendarApiRef {
+    /**
+     * Method to navigate to today's date
+     */
+    goToToday: () => void;
+
+    /**
+     * Method to set the current month (0-11) 0 = January, 11 = December
+     */
+    setMonth: (month: MonthIndex) => void;
+
+    /**
+     * Method to set the current year
+     */
+    setYear: (year: number) => void;
+    
+    /**
+     * Method to set the current date
+     */
+    setDate: (date: Date) => void;
+}
 export interface DataState {
     loading?: boolean;
     error?: Error | null;


### PR DESCRIPTION
Devs can now do:

```ts
const apiRef = useApiRef();

apiRef.current?.goToToday();
apiRef.current?.setMonth(11)
apiRef.current?.setYear(2024)
apiRef.current?.setDate(new Date(2024, 5, 19));

<FastCalendar
   apiRef={apiRef}
/>
```

as an example:

```ts
 useEffect(() => {
    if (apiRef.current) {
      setTimeout(() => {
        apiRef.current?.setDate(new Date(2022, 0, 1));
      }, 3000);
    }
  }, [apiRef]);
  ```